### PR TITLE
Request admin privileges instead of highest

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -30,7 +30,7 @@ ${StrCase}
 ;General
 
   ; Request application privileges for Windows Vista
-  RequestExecutionLevel highest
+  RequestExecutionLevel admin
 
   !define MUI_ICON "resources\particle.ico"
 


### PR DESCRIPTION
Requesting `highest` privileges work for an interactive session, but starting the installer in silent mode from another installer like the CLI installer doesn't actually show the UAC prompt. Requesting `admin` works in both cases.